### PR TITLE
Limit to 50 frameworks per language

### DIFF
--- a/.semaphore/schedule.yml
+++ b/.semaphore/schedule.yml
@@ -2687,23 +2687,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/phalcon
-    - name: mixphp-swoole
-      commands:
-      - cd php/mixphp-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp-swoole
     - name: one-fpm
       commands:
       - cd php/one-fpm && make build  -f .Makefile  && cd -
@@ -3061,23 +3044,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/mezzio
-    - name: mixphp-workerman
-      commands:
-      - cd php/mixphp-workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp-workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp-workerman
     - name: lumen
       commands:
       - cd php/lumen && make build  -f .Makefile  && cd -
@@ -3231,23 +3197,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/symfony
-    - name: mixphp
-      commands:
-      - cd php/mixphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp
     - name: slim
       commands:
       - cd php/slim && make build  -f .Makefile  && cd -

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2719,23 +2719,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/phalcon
-    - name: mixphp-swoole
-      commands:
-      - cd php/mixphp-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp-swoole
     - name: one-fpm
       commands:
       - cd php/one-fpm && make build  -f .Makefile  && cd -
@@ -3093,23 +3076,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/mezzio
-    - name: mixphp-workerman
-      commands:
-      - cd php/mixphp-workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp-workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp-workerman
     - name: lumen
       commands:
       - cd php/lumen && make build  -f .Makefile  && cd -
@@ -3263,23 +3229,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/symfony
-    - name: mixphp
-      commands:
-      - cd php/mixphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mixphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mixphp
     - name: slim
       commands:
       - cd php/slim && make build  -f .Makefile  && cd -

--- a/.tasks/ci.rake
+++ b/.tasks/ci.rake
@@ -40,6 +40,7 @@ namespace :ci do
       ] }, jobs: [] } }
       Dir.glob("#{language}/*/config.yaml") do |file|
         _, framework, = file.split(File::Separator)
+        next if language == 'php' && framework.start_with?('mixphp')
         block[:task][:jobs] << { name: framework, commands: [
           "cd #{language}/#{framework} && make build  -f #{MANIFESTS[:build]}  && cd -",
           'bundle exec rspec .spec',
@@ -53,6 +54,7 @@ namespace :ci do
           { name: 'FRAMEWORK', value: "#{language}/#{framework}" }
         ] }
         block[:task].merge!(epilogue: { commands: ['docker logs `cat ${FRAMEWORK}/cid.txt`'] })
+        break if block[:task][:jobs].count == 50
       end
       blocks << block
     end


### PR DESCRIPTION
Hi @onanying,

This `PR` fix ci for `mixphp`. 

The CI tool in used (at least for OSS) could run only 50 tasks per blocks (1 block per language and 1 task per framework).

With https://github.com/the-benchmarker/web-frameworks/pull/3958, we will run 1 block per framework (each job will be a config, 1 job for swoole, 1 for workerman ...).

Regards,