### PR TITLE
Run CI on last modified frameworks (50) per language

### DIFF
--- a/.semaphore/schedule.yml
+++ b/.semaphore/schedule.yml
@@ -81,193 +81,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: chi
-      commands:
-      - cd go/chi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/chi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/chi
-    - name: violetear
-      commands:
-      - cd go/violetear && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/violetear/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/violetear
-    - name: httprouter
-      commands:
-      - cd go/httprouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/httprouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/httprouter
-    - name: macaron
-      commands:
-      - cd go/macaron && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/macaron/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/macaron
-    - name: gramework
-      commands:
-      - cd go/gramework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gramework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gramework
-    - name: gearbox
-      commands:
-      - cd go/gearbox && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gearbox/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gearbox
-    - name: fasthttp
-      commands:
-      - cd go/fasthttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/fasthttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/fasthttp
-    - name: gf
-      commands:
-      - cd go/gf && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gf/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gf
-    - name: echo
-      commands:
-      - cd go/echo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/echo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/echo
-    - name: gorouter
-      commands:
-      - cd go/gorouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorouter
-    - name: apirouter
-      commands:
-      - cd go/apirouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/apirouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/apirouter
     - name: goyave
       commands:
       - cd go/goyave && make build  -f .Makefile  && cd -
@@ -285,11 +98,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/goyave
-    - name: atreugo
+    - name: fasthttp
       commands:
-      - cd go/atreugo && make build  -f .Makefile  && cd -
+      - cd go/fasthttp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f go/atreugo/.Makefile collect
+      - make  -f go/fasthttp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -301,7 +114,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: go/atreugo
+        value: go/fasthttp
+    - name: apirouter
+      commands:
+      - cd go/apirouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/apirouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/apirouter
     - name: kami
       commands:
       - cd go/kami && make build  -f .Makefile  && cd -
@@ -319,40 +149,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/kami
-    - name: aero
-      commands:
-      - cd go/aero && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/aero/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/aero
-    - name: air
-      commands:
-      - cd go/air && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/air/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/air
     - name: tango
       commands:
       - cd go/tango && make build  -f .Makefile  && cd -
@@ -370,11 +166,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/tango
-    - name: goroute
+    - name: gramework
       commands:
-      - cd go/goroute && make build  -f .Makefile  && cd -
+      - cd go/gramework && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f go/goroute/.Makefile collect
+      - make  -f go/gramework/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -386,58 +182,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: go/goroute
-    - name: beego
-      commands:
-      - cd go/beego && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/beego/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/beego
-    - name: gorouter-fasthttp
-      commands:
-      - cd go/gorouter-fasthttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorouter-fasthttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorouter-fasthttp
-    - name: fiber
-      commands:
-      - cd go/fiber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/fiber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/fiber
+        value: go/gramework
     - name: rte
       commands:
       - cd go/rte && make build  -f .Makefile  && cd -
@@ -455,74 +200,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/rte
-    - name: clevergo
-      commands:
-      - cd go/clevergo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/clevergo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/clevergo
-    - name: gorilla-mux
-      commands:
-      - cd go/gorilla-mux && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorilla-mux/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorilla-mux
-    - name: mars
-      commands:
-      - cd go/mars && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/mars/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/mars
-    - name: gin
-      commands:
-      - cd go/gin && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gin/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gin
     - name: webgo
       commands:
       - cd go/webgo && make build  -f .Makefile  && cd -
@@ -557,6 +234,329 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/router
+    - name: mars
+      commands:
+      - cd go/mars && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/mars/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/mars
+    - name: gf
+      commands:
+      - cd go/gf && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gf/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gf
+    - name: fiber
+      commands:
+      - cd go/fiber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/fiber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/fiber
+    - name: echo
+      commands:
+      - cd go/echo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/echo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/echo
+    - name: clevergo
+      commands:
+      - cd go/clevergo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/clevergo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/clevergo
+    - name: beego
+      commands:
+      - cd go/beego && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/beego/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/beego
+    - name: atreugo
+      commands:
+      - cd go/atreugo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/atreugo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/atreugo
+    - name: air
+      commands:
+      - cd go/air && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/air/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/air
+    - name: macaron
+      commands:
+      - cd go/macaron && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/macaron/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/macaron
+    - name: gin
+      commands:
+      - cd go/gin && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gin/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gin
+    - name: gearbox
+      commands:
+      - cd go/gearbox && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gearbox/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gearbox
+    - name: chi
+      commands:
+      - cd go/chi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/chi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/chi
+    - name: violetear
+      commands:
+      - cd go/violetear && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/violetear/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/violetear
+    - name: gorouter
+      commands:
+      - cd go/gorouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorouter
+    - name: gorouter-fasthttp
+      commands:
+      - cd go/gorouter-fasthttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorouter-fasthttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorouter-fasthttp
+    - name: goroute
+      commands:
+      - cd go/goroute && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/goroute/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/goroute
+    - name: gorilla-mux
+      commands:
+      - cd go/gorilla-mux && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorilla-mux/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorilla-mux
+    - name: httprouter
+      commands:
+      - cd go/httprouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/httprouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/httprouter
+    - name: aero
+      commands:
+      - cd go/aero && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/aero/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/aero
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -578,57 +578,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: mike
-      commands:
-      - cd nim/mike && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/mike/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/mike
-    - name: prologue
-      commands:
-      - cd nim/prologue && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/prologue/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/prologue
-    - name: akane
-      commands:
-      - cd nim/akane && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/akane/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/akane
     - name: httpbeast
       commands:
       - cd nim/httpbeast && make build  -f .Makefile  && cd -
@@ -646,6 +595,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/httpbeast
+    - name: akane
+      commands:
+      - cd nim/akane && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/akane/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/akane
     - name: scorper
       commands:
       - cd nim/scorper && make build  -f .Makefile  && cd -
@@ -663,11 +629,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/scorper
-    - name: jester
+    - name: prologue
       commands:
-      - cd nim/jester && make build  -f .Makefile  && cd -
+      - cd nim/prologue && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f nim/jester/.Makefile collect
+      - make  -f nim/prologue/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -679,7 +645,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: nim/jester
+        value: nim/prologue
+    - name: mike
+      commands:
+      - cd nim/mike && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/mike/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/mike
     - name: whip
       commands:
       - cd nim/whip && make build  -f .Makefile  && cd -
@@ -714,6 +697,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/rosencrantz
+    - name: jester
+      commands:
+      - cd nim/jester && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/jester/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/jester
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -735,40 +735,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: flask
-      commands:
-      - cd python/flask && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/flask/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/flask
-    - name: aiohttp
-      commands:
-      - cd python/aiohttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/aiohttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/aiohttp
     - name: apidaora
       commands:
       - cd python/apidaora && make build  -f .Makefile  && cd -
@@ -786,40 +752,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/apidaora
-    - name: masonite
-      commands:
-      - cd python/masonite && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/masonite/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/masonite
-    - name: clastic
-      commands:
-      - cd python/clastic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/clastic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/clastic
     - name: guillotina
       commands:
       - cd python/guillotina && make build  -f .Makefile  && cd -
@@ -837,6 +769,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/guillotina
+    - name: flask
+      commands:
+      - cd python/flask && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/flask/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/flask
     - name: index.py
       commands:
       - cd python/index.py && make build  -f .Makefile  && cd -
@@ -871,6 +820,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/quart
+    - name: clastic
+      commands:
+      - cd python/clastic && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/clastic/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/clastic
+    - name: masonite
+      commands:
+      - cd python/masonite && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/masonite/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/masonite
+    - name: cherrypy
+      commands:
+      - cd python/cherrypy && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/cherrypy/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/cherrypy
     - name: pyramid
       commands:
       - cd python/pyramid && make build  -f .Makefile  && cd -
@@ -905,227 +905,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/starlette
-    - name: cherrypy
-      commands:
-      - cd python/cherrypy && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/cherrypy/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/cherrypy
-    - name: emmett
-      commands:
-      - cd python/emmett && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/emmett/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/emmett
-    - name: hug
-      commands:
-      - cd python/hug && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/hug/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/hug
-    - name: blacksheep
-      commands:
-      - cd python/blacksheep && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/blacksheep/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/blacksheep
-    - name: baize-wsgi
-      commands:
-      - cd python/baize-wsgi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/baize-wsgi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/baize-wsgi
-    - name: molten
-      commands:
-      - cd python/molten && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/molten/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/molten
-    - name: tornado
-      commands:
-      - cd python/tornado && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/tornado/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/tornado
-    - name: tonberry
-      commands:
-      - cd python/tonberry && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/tonberry/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/tonberry
-    - name: nameko
-      commands:
-      - cd python/nameko && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/nameko/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/nameko
-    - name: fastapi
-      commands:
-      - cd python/fastapi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/fastapi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/fastapi
-    - name: klein
-      commands:
-      - cd python/klein && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/klein/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/klein
-    - name: sanic
-      commands:
-      - cd python/sanic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/sanic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/sanic
-    - name: responder
-      commands:
-      - cd python/responder && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/responder/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/responder
     - name: asgineer
       commands:
       - cd python/asgineer && make build  -f .Makefile  && cd -
@@ -1143,11 +922,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/asgineer
-    - name: django-ninja
+    - name: emmett
       commands:
-      - cd python/django-ninja && make build  -f .Makefile  && cd -
+      - cd python/emmett && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/django-ninja/.Makefile collect
+      - make  -f python/emmett/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1159,12 +938,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/django-ninja
-    - name: baize-asgi
+        value: python/emmett
+    - name: baize-wsgi
       commands:
-      - cd python/baize-asgi && make build  -f .Makefile  && cd -
+      - cd python/baize-wsgi && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/baize-asgi/.Makefile collect
+      - make  -f python/baize-wsgi/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1176,12 +955,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/baize-asgi
-    - name: cyclone
+        value: python/baize-wsgi
+    - name: blacksheep
       commands:
-      - cd python/cyclone && make build  -f .Makefile  && cd -
+      - cd python/blacksheep && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/cyclone/.Makefile collect
+      - make  -f python/blacksheep/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1193,12 +972,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/cyclone
-    - name: django
+        value: python/blacksheep
+    - name: hug
       commands:
-      - cd python/django && make build  -f .Makefile  && cd -
+      - cd python/hug && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/django/.Makefile collect
+      - make  -f python/hug/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1210,7 +989,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/django
+        value: python/hug
+    - name: aiohttp
+      commands:
+      - cd python/aiohttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/aiohttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/aiohttp
     - name: falcon
       commands:
       - cd python/falcon && make build  -f .Makefile  && cd -
@@ -1228,6 +1024,125 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/falcon
+    - name: molten
+      commands:
+      - cd python/molten && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/molten/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/molten
+    - name: tonberry
+      commands:
+      - cd python/tonberry && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/tonberry/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/tonberry
+    - name: klein
+      commands:
+      - cd python/klein && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/klein/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/klein
+    - name: fastapi
+      commands:
+      - cd python/fastapi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/fastapi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/fastapi
+    - name: responder
+      commands:
+      - cd python/responder && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/responder/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/responder
+    - name: django-ninja
+      commands:
+      - cd python/django-ninja && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/django-ninja/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/django-ninja
+    - name: django
+      commands:
+      - cd python/django && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/django/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/django
     - name: bottle
       commands:
       - cd python/bottle && make build  -f .Makefile  && cd -
@@ -1245,6 +1160,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/bottle
+    - name: baize-asgi
+      commands:
+      - cd python/baize-asgi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/baize-asgi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/baize-asgi
+    - name: sanic
+      commands:
+      - cd python/sanic && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/sanic/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/sanic
+    - name: cyclone
+      commands:
+      - cd python/cyclone && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/cyclone/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/cyclone
+    - name: tornado
+      commands:
+      - cd python/tornado && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/tornado/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/tornado
+    - name: nameko
+      commands:
+      - cd python/nameko && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/nameko/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/nameko
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1283,6 +1283,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: clojure/donkey
+    - name: luminus
+      commands:
+      - cd clojure/luminus && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f clojure/luminus/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: clojure/luminus
     - name: yada
       commands:
       - cd clojure/yada && make build  -f .Makefile  && cd -
@@ -1317,23 +1334,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: clojure/coast
-    - name: luminus
-      commands:
-      - cd clojure/luminus && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f clojure/luminus/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: clojure/luminus
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1355,57 +1355,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: cowboy
-      commands:
-      - cd elixir/cowboy && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/cowboy/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/cowboy
-    - name: cowboy_stream
-      commands:
-      - cd elixir/cowboy_stream && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/cowboy_stream/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/cowboy_stream
-    - name: phoenix
-      commands:
-      - cd elixir/phoenix && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/phoenix/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/phoenix
     - name: plug
       commands:
       - cd elixir/plug && make build  -f .Makefile  && cd -
@@ -1423,6 +1372,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: elixir/plug
+    - name: cowboy_stream
+      commands:
+      - cd elixir/cowboy_stream && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/cowboy_stream/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/cowboy_stream
+    - name: cowboy
+      commands:
+      - cd elixir/cowboy && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/cowboy/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/cowboy
+    - name: phoenix
+      commands:
+      - cd elixir/phoenix && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/phoenix/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/phoenix
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1520,57 +1520,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: gotham
-      commands:
-      - cd rust/gotham && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/gotham/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/gotham
-    - name: iron
-      commands:
-      - cd rust/iron && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/iron/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/iron
-    - name: nickel
-      commands:
-      - cd rust/nickel && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/nickel/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/nickel
     - name: salvo
       commands:
       - cd rust/salvo && make build  -f .Makefile  && cd -
@@ -1588,6 +1537,40 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: rust/salvo
+    - name: iron
+      commands:
+      - cd rust/iron && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/iron/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/iron
+    - name: gotham
+      commands:
+      - cd rust/gotham && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/gotham/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/gotham
     - name: actix
       commands:
       - cd rust/actix && make build  -f .Makefile  && cd -
@@ -1605,6 +1588,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: rust/actix
+    - name: nickel
+      commands:
+      - cd rust/nickel && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/nickel/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/nickel
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1626,91 +1626,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: giraffe
-      commands:
-      - cd fsharp/giraffe && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/giraffe/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/giraffe
-    - name: websharper
-      commands:
-      - cd fsharp/websharper && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/websharper/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/websharper
-    - name: saturn
-      commands:
-      - cd fsharp/saturn && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/saturn/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/saturn
-    - name: frank
-      commands:
-      - cd fsharp/frank && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/frank/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/frank
-    - name: suave
-      commands:
-      - cd fsharp/suave && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/suave/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/suave
     - name: falco
       commands:
       - cd fsharp/falco && make build  -f .Makefile  && cd -
@@ -1728,6 +1643,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: fsharp/falco
+    - name: websharper
+      commands:
+      - cd fsharp/websharper && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/websharper/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/websharper
+    - name: suave
+      commands:
+      - cd fsharp/suave && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/suave/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/suave
+    - name: frank
+      commands:
+      - cd fsharp/frank && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/frank/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/frank
+    - name: saturn
+      commands:
+      - cd fsharp/saturn && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/saturn/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/saturn
+    - name: giraffe
+      commands:
+      - cd fsharp/giraffe && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/giraffe/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/giraffe
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1749,40 +1749,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: plumber
-      commands:
-      - cd r/plumber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f r/plumber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: r/plumber
-    - name: restrserve
-      commands:
-      - cd r/restrserve && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f r/restrserve/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: r/restrserve
     - name: rserve
       commands:
       - cd r/rserve && make build  -f .Makefile  && cd -
@@ -1800,6 +1766,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: r/rserve
+    - name: restrserve
+      commands:
+      - cd r/restrserve && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f r/restrserve/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: r/restrserve
     - name: httpuv
       commands:
       - cd r/httpuv && make build  -f .Makefile  && cd -
@@ -1817,6 +1800,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: r/httpuv
+    - name: plumber
+      commands:
+      - cd r/plumber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f r/plumber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: r/plumber
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1838,244 +1838,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: quarkus
-      commands:
-      - cd java/quarkus && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/quarkus/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/quarkus
-    - name: restheart
-      commands:
-      - cd java/restheart && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/restheart/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/restheart
-    - name: light-4j
-      commands:
-      - cd java/light-4j && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/light-4j/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/light-4j
-    - name: vertx
-      commands:
-      - cd java/vertx && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/vertx/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/vertx
-    - name: jooby
-      commands:
-      - cd java/jooby && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jooby/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jooby
-    - name: activej
-      commands:
-      - cd java/activej && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/activej/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/activej
-    - name: jersey-grizzly2
-      commands:
-      - cd java/jersey-grizzly2 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jersey-grizzly2/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jersey-grizzly2
-    - name: javalin
-      commands:
-      - cd java/javalin && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/javalin/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/javalin
-    - name: jersey3-grizzly2
-      commands:
-      - cd java/jersey3-grizzly2 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jersey3-grizzly2/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jersey3-grizzly2
-    - name: act
-      commands:
-      - cd java/act && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/act/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/act
-    - name: rapidoid
-      commands:
-      - cd java/rapidoid && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/rapidoid/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/rapidoid
-    - name: vertx4web
-      commands:
-      - cd java/vertx4web && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/vertx4web/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/vertx4web
-    - name: undertow
-      commands:
-      - cd java/undertow && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/undertow/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/undertow
-    - name: blade
-      commands:
-      - cd java/blade && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/blade/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/blade
     - name: struts2
       commands:
       - cd java/struts2 && make build  -f .Makefile  && cd -
@@ -2093,11 +1855,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: java/struts2
-    - name: micronaut
+    - name: quarkus
       commands:
-      - cd java/micronaut && make build  -f .Makefile  && cd -
+      - cd java/quarkus && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f java/micronaut/.Makefile collect
+      - make  -f java/quarkus/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2109,12 +1871,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: java/micronaut
-    - name: spark
+        value: java/quarkus
+    - name: vertx4web
       commands:
-      - cd java/spark && make build  -f .Makefile  && cd -
+      - cd java/vertx4web && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f java/spark/.Makefile collect
+      - make  -f java/vertx4web/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2126,7 +1888,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: java/spark
+        value: java/vertx4web
+    - name: vertx
+      commands:
+      - cd java/vertx && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/vertx/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/vertx
     - name: spring
       commands:
       - cd java/spring && make build  -f .Makefile  && cd -
@@ -2144,6 +1923,227 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: java/spring
+    - name: restheart
+      commands:
+      - cd java/restheart && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/restheart/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/restheart
+    - name: jooby
+      commands:
+      - cd java/jooby && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jooby/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jooby
+    - name: jersey-grizzly2
+      commands:
+      - cd java/jersey-grizzly2 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jersey-grizzly2/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jersey-grizzly2
+    - name: activej
+      commands:
+      - cd java/activej && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/activej/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/activej
+    - name: undertow
+      commands:
+      - cd java/undertow && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/undertow/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/undertow
+    - name: spark
+      commands:
+      - cd java/spark && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/spark/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/spark
+    - name: rapidoid
+      commands:
+      - cd java/rapidoid && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/rapidoid/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/rapidoid
+    - name: micronaut
+      commands:
+      - cd java/micronaut && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/micronaut/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/micronaut
+    - name: light-4j
+      commands:
+      - cd java/light-4j && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/light-4j/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/light-4j
+    - name: jersey3-grizzly2
+      commands:
+      - cd java/jersey3-grizzly2 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jersey3-grizzly2/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jersey3-grizzly2
+    - name: javalin
+      commands:
+      - cd java/javalin && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/javalin/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/javalin
+    - name: act
+      commands:
+      - cd java/act && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/act/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/act
+    - name: blade
+      commands:
+      - cd java/blade && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/blade/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/blade
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2165,6 +2165,23 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
+    - name: ktor
+      commands:
+      - cd kotlin/ktor && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f kotlin/ktor/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: kotlin/ktor
     - name: kooby
       commands:
       - cd kotlin/kooby && make build  -f .Makefile  && cd -
@@ -2199,23 +2216,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: kotlin/http4k
-    - name: ktor
-      commands:
-      - cd kotlin/ktor && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f kotlin/ktor/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: kotlin/ktor
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2237,108 +2237,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: shivneri
-      commands:
-      - cd crystal/shivneri && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/shivneri/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/shivneri
-    - name: orion
-      commands:
-      - cd crystal/orion && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/orion/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/orion
-    - name: amber
-      commands:
-      - cd crystal/amber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/amber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/amber
-    - name: router.cr
-      commands:
-      - cd crystal/router.cr && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/router.cr/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/router.cr
-    - name: runcobo
-      commands:
-      - cd crystal/runcobo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/runcobo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/runcobo
-    - name: toro
-      commands:
-      - cd crystal/toro && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/toro/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/toro
     - name: spider-gazelle
       commands:
       - cd crystal/spider-gazelle && make build  -f .Makefile  && cd -
@@ -2356,11 +2254,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: crystal/spider-gazelle
-    - name: grip
+    - name: shivneri
       commands:
-      - cd crystal/grip && make build  -f .Makefile  && cd -
+      - cd crystal/shivneri && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f crystal/grip/.Makefile collect
+      - make  -f crystal/shivneri/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2372,7 +2270,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: crystal/grip
+        value: crystal/shivneri
+    - name: runcobo
+      commands:
+      - cd crystal/runcobo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/runcobo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/runcobo
     - name: kemal
       commands:
       - cd crystal/kemal && make build  -f .Makefile  && cd -
@@ -2407,6 +2322,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: crystal/athena
+    - name: amber
+      commands:
+      - cd crystal/amber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/amber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/amber
+    - name: grip
+      commands:
+      - cd crystal/grip && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/grip/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/grip
+    - name: toro
+      commands:
+      - cd crystal/toro && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/toro/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/toro
+    - name: router.cr
+      commands:
+      - cd crystal/router.cr && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/router.cr/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/router.cr
+    - name: orion
+      commands:
+      - cd crystal/orion && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/orion/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/orion
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2428,23 +2428,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: scotty
-      commands:
-      - cd haskell/scotty && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f haskell/scotty/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: haskell/scotty
     - name: servant
       commands:
       - cd haskell/servant && make build  -f .Makefile  && cd -
@@ -2462,6 +2445,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: haskell/servant
+    - name: scotty
+      commands:
+      - cd haskell/scotty && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f haskell/scotty/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: haskell/scotty
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2483,11 +2483,11 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: slim-swoole
+    - name: mixphp
       commands:
-      - cd php/slim-swoole && make build  -f .Makefile  && cd -
+      - cd php/mixphp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/slim-swoole/.Makefile collect
+      - make  -f php/mixphp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2499,12 +2499,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/slim-swoole
-    - name: chubbyphp-swoole
+        value: php/mixphp
+    - name: mixphp-workerman
       commands:
-      - cd php/chubbyphp-swoole && make build  -f .Makefile  && cd -
+      - cd php/mixphp-workerman && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/chubbyphp-swoole/.Makefile collect
+      - make  -f php/mixphp-workerman/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2516,12 +2516,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/chubbyphp-swoole
-    - name: sunrise-router-roadrunner
+        value: php/mixphp-workerman
+    - name: mixphp-swoole
       commands:
-      - cd php/sunrise-router-roadrunner && make build  -f .Makefile  && cd -
+      - cd php/mixphp-swoole && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/sunrise-router-roadrunner/.Makefile collect
+      - make  -f php/mixphp-swoole/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2533,755 +2533,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/sunrise-router-roadrunner
-    - name: cubex
-      commands:
-      - cd php/cubex && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/cubex/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/cubex
-    - name: swoole
-      commands:
-      - cd php/swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoole
-    - name: slim-roadrunner
-      commands:
-      - cd php/slim-roadrunner && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/slim-roadrunner/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/slim-roadrunner
-    - name: swoft
-      commands:
-      - cd php/swoft && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoft/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoft
-    - name: simps
-      commands:
-      - cd php/simps && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/simps/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/simps
-    - name: nano
-      commands:
-      - cd php/nano && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/nano/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/nano
-    - name: codeigniter4
-      commands:
-      - cd php/codeigniter4 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/codeigniter4/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/codeigniter4
-    - name: yii
-      commands:
-      - cd php/yii && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/yii/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/yii
-    - name: phalcon
-      commands:
-      - cd php/phalcon && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/phalcon/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/phalcon
-    - name: one-fpm
-      commands:
-      - cd php/one-fpm && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/one-fpm/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/one-fpm
-    - name: ice
-      commands:
-      - cd php/ice && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/ice/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/ice
-    - name: spiral
-      commands:
-      - cd php/spiral && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/spiral/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/spiral
-    - name: mark
-      commands:
-      - cd php/mark && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mark/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mark
-    - name: siler-swoole
-      commands:
-      - cd php/siler-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/siler-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/siler-swoole
-    - name: workerman
-      commands:
-      - cd php/workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/workerman
-    - name: chubbyphp-roadrunner
-      commands:
-      - cd php/chubbyphp-roadrunner && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp-roadrunner/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp-roadrunner
-    - name: nette
-      commands:
-      - cd php/nette && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/nette/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/nette
-    - name: webman
-      commands:
-      - cd php/webman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/webman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/webman
-    - name: driftphp
-      commands:
-      - cd php/driftphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/driftphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/driftphp
-    - name: sw-fw-less
-      commands:
-      - cd php/sw-fw-less && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sw-fw-less/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sw-fw-less
-    - name: laminas
-      commands:
-      - cd php/laminas && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/laminas/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/laminas
-    - name: chubbyphp
-      commands:
-      - cd php/chubbyphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp
-    - name: imi
-      commands:
-      - cd php/imi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/imi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/imi
-    - name: unic
-      commands:
-      - cd php/unic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/unic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/unic
-    - name: basicphp
-      commands:
-      - cd php/basicphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/basicphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/basicphp
-    - name: comet
-      commands:
-      - cd php/comet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/comet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/comet
-    - name: sunrise-router
-      commands:
-      - cd php/sunrise-router && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sunrise-router/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sunrise-router
-    - name: ubiquity
-      commands:
-      - cd php/ubiquity && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/ubiquity/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/ubiquity
-    - name: one
-      commands:
-      - cd php/one && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/one/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/one
-    - name: mezzio
-      commands:
-      - cd php/mezzio && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mezzio/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mezzio
-    - name: lumen
-      commands:
-      - cd php/lumen && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/lumen/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/lumen
-    - name: antidot
-      commands:
-      - cd php/antidot && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/antidot/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/antidot
-    - name: siler
-      commands:
-      - cd php/siler && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/siler/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/siler
-    - name: fastsitephp
-      commands:
-      - cd php/fastsitephp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/fastsitephp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/fastsitephp
-    - name: bearframework
-      commands:
-      - cd php/bearframework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/bearframework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/bearframework
-    - name: laravel-s-laravel
-      commands:
-      - cd php/laravel-s-laravel && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/laravel-s-laravel/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/laravel-s-laravel
-    - name: hamlet
-      commands:
-      - cd php/hamlet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/hamlet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/hamlet
-    - name: swoole-coroutine
-      commands:
-      - cd php/swoole-coroutine && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoole-coroutine/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoole-coroutine
-    - name: symfony
-      commands:
-      - cd php/symfony && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/symfony/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/symfony
-    - name: slim
-      commands:
-      - cd php/slim && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/slim/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/slim
-    - name: chubbyphp-workerman
-      commands:
-      - cd php/chubbyphp-workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp-workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp-workerman
-    - name: sunrise-router-annotations
-      commands:
-      - cd php/sunrise-router-annotations && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sunrise-router-annotations/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sunrise-router-annotations
-    - name: yii-swoole
-      commands:
-      - cd php/yii-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/yii-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/yii-swoole
-    - name: fatfree
-      commands:
-      - cd php/fatfree && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/fatfree/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/fatfree
+        value: php/mixphp-swoole
     - name: laravel
       commands:
       - cd php/laravel && make build  -f .Makefile  && cd -
@@ -3299,11 +2551,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/laravel
-    - name: hyperf
+    - name: driftphp
       commands:
-      - cd php/hyperf && make build  -f .Makefile  && cd -
+      - cd php/driftphp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/hyperf/.Makefile collect
+      - make  -f php/driftphp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -3315,7 +2567,279 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/hyperf
+        value: php/driftphp
+    - name: workerman
+      commands:
+      - cd php/workerman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/workerman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/workerman
+    - name: webman
+      commands:
+      - cd php/webman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/webman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/webman
+    - name: symfony
+      commands:
+      - cd php/symfony && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/symfony/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/symfony
+    - name: swoole
+      commands:
+      - cd php/swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoole
+    - name: swoole-coroutine
+      commands:
+      - cd php/swoole-coroutine && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoole-coroutine/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoole-coroutine
+    - name: sunrise-router
+      commands:
+      - cd php/sunrise-router && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router
+    - name: sunrise-router-roadrunner
+      commands:
+      - cd php/sunrise-router-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router-roadrunner
+    - name: sunrise-router-annotations
+      commands:
+      - cd php/sunrise-router-annotations && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router-annotations/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router-annotations
+    - name: spiral
+      commands:
+      - cd php/spiral && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/spiral/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/spiral
+    - name: slim
+      commands:
+      - cd php/slim && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim
+    - name: slim-swoole
+      commands:
+      - cd php/slim-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim-swoole
+    - name: slim-roadrunner
+      commands:
+      - cd php/slim-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim-roadrunner
+    - name: phalcon
+      commands:
+      - cd php/phalcon && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/phalcon/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/phalcon
+    - name: nano
+      commands:
+      - cd php/nano && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/nano/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/nano
+    - name: mezzio
+      commands:
+      - cd php/mezzio && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/mezzio/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/mezzio
+    - name: mark
+      commands:
+      - cd php/mark && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/mark/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/mark
     - name: laravel-s-lumen
       commands:
       - cd php/laravel-s-lumen && make build  -f .Makefile  && cd -
@@ -3333,6 +2857,482 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/laravel-s-lumen
+    - name: laravel-s-laravel
+      commands:
+      - cd php/laravel-s-laravel && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/laravel-s-laravel/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/laravel-s-laravel
+    - name: imi
+      commands:
+      - cd php/imi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/imi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/imi
+    - name: ice
+      commands:
+      - cd php/ice && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/ice/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/ice
+    - name: hyperf
+      commands:
+      - cd php/hyperf && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/hyperf/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/hyperf
+    - name: hamlet
+      commands:
+      - cd php/hamlet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/hamlet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/hamlet
+    - name: comet
+      commands:
+      - cd php/comet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/comet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/comet
+    - name: codeigniter4
+      commands:
+      - cd php/codeigniter4 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/codeigniter4/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/codeigniter4
+    - name: chubbyphp
+      commands:
+      - cd php/chubbyphp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp
+    - name: chubbyphp-workerman
+      commands:
+      - cd php/chubbyphp-workerman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-workerman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-workerman
+    - name: chubbyphp-swoole
+      commands:
+      - cd php/chubbyphp-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-swoole
+    - name: chubbyphp-roadrunner
+      commands:
+      - cd php/chubbyphp-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-roadrunner
+    - name: antidot
+      commands:
+      - cd php/antidot && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/antidot/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/antidot
+    - name: yii
+      commands:
+      - cd php/yii && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/yii/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/yii
+    - name: yii-swoole
+      commands:
+      - cd php/yii-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/yii-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/yii-swoole
+    - name: ubiquity
+      commands:
+      - cd php/ubiquity && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/ubiquity/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/ubiquity
+    - name: swoft
+      commands:
+      - cd php/swoft && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoft/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoft
+    - name: sw-fw-less
+      commands:
+      - cd php/sw-fw-less && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sw-fw-less/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sw-fw-less
+    - name: simps
+      commands:
+      - cd php/simps && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/simps/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/simps
+    - name: siler
+      commands:
+      - cd php/siler && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/siler/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/siler
+    - name: siler-swoole
+      commands:
+      - cd php/siler-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/siler-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/siler-swoole
+    - name: one
+      commands:
+      - cd php/one && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/one/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/one
+    - name: one-fpm
+      commands:
+      - cd php/one-fpm && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/one-fpm/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/one-fpm
+    - name: nette
+      commands:
+      - cd php/nette && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/nette/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/nette
+    - name: lumen
+      commands:
+      - cd php/lumen && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/lumen/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/lumen
+    - name: laminas
+      commands:
+      - cd php/laminas && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/laminas/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/laminas
+    - name: cubex
+      commands:
+      - cd php/cubex && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/cubex/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/cubex
+    - name: bearframework
+      commands:
+      - cd php/bearframework && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/bearframework/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/bearframework
+    - name: basicphp
+      commands:
+      - cd php/basicphp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/basicphp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/basicphp
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3354,40 +3354,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: akkahttp
-      commands:
-      - cd scala/akkahttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/akkahttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/akkahttp
-    - name: finch
-      commands:
-      - cd scala/finch && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/finch/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/finch
     - name: finatra
       commands:
       - cd scala/finatra && make build  -f .Makefile  && cd -
@@ -3405,23 +3371,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: scala/finatra
-    - name: play
-      commands:
-      - cd scala/play && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/play/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/play
     - name: http4s
       commands:
       - cd scala/http4s && make build  -f .Makefile  && cd -
@@ -3439,6 +3388,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: scala/http4s
+    - name: finch
+      commands:
+      - cd scala/finch && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/finch/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/finch
+    - name: akkahttp
+      commands:
+      - cd scala/akkahttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/akkahttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/akkahttp
+    - name: play
+      commands:
+      - cd scala/play && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/play/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/play
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3477,23 +3477,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: cpp/nawa
-    - name: drogon
-      commands:
-      - cd cpp/drogon && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f cpp/drogon/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: cpp/drogon
     - name: evhtp
       commands:
       - cd cpp/evhtp && make build  -f .Makefile  && cd -
@@ -3511,6 +3494,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: cpp/evhtp
+    - name: drogon
+      commands:
+      - cd cpp/drogon && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f cpp/drogon/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: cpp/drogon
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3532,40 +3532,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: swifter-framework
-      commands:
-      - cd swift/swifter-framework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/swifter-framework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/swifter-framework
-    - name: perfect
-      commands:
-      - cd swift/perfect && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/perfect/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/perfect
     - name: hummingbird-framework
       commands:
       - cd swift/hummingbird-framework && make build  -f .Makefile  && cd -
@@ -3583,23 +3549,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: swift/hummingbird-framework
-    - name: kitura-nio
-      commands:
-      - cd swift/kitura-nio && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/kitura-nio/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/kitura-nio
     - name: vapor-framework
       commands:
       - cd swift/vapor-framework && make build  -f .Makefile  && cd -
@@ -3634,6 +3583,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: swift/kitura
+    - name: kitura-nio
+      commands:
+      - cd swift/kitura-nio && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/kitura-nio/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/kitura-nio
+    - name: swifter-framework
+      commands:
+      - cd swift/swifter-framework && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/swifter-framework/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/swifter-framework
+    - name: perfect
+      commands:
+      - cd swift/perfect && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/perfect/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/perfect
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3655,40 +3655,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: aspnetcore
-      commands:
-      - cd csharp/aspnetcore && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f csharp/aspnetcore/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: csharp/aspnetcore
-    - name: carter
-      commands:
-      - cd csharp/carter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f csharp/carter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: csharp/carter
     - name: beetlex
       commands:
       - cd csharp/beetlex && make build  -f .Makefile  && cd -
@@ -3723,6 +3689,40 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: csharp/simplify.web
+    - name: carter
+      commands:
+      - cd csharp/carter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f csharp/carter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: csharp/carter
+    - name: aspnetcore
+      commands:
+      - cd csharp/aspnetcore && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f csharp/aspnetcore/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: csharp/aspnetcore
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3782,380 +3782,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: moleculer
-      commands:
-      - cd javascript/moleculer && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/moleculer/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/moleculer
-    - name: polka
-      commands:
-      - cd javascript/polka && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/polka/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/polka
-    - name: foxify
-      commands:
-      - cd javascript/foxify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/foxify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/foxify
-    - name: 0http
-      commands:
-      - cd javascript/0http && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/0http/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/0http
-    - name: sifrr
-      commands:
-      - cd javascript/sifrr && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/sifrr/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/sifrr
-    - name: nestjs-fastify
-      commands:
-      - cd javascript/nestjs-fastify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nestjs-fastify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nestjs-fastify
-    - name: restana
-      commands:
-      - cd javascript/restana && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/restana/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/restana
-    - name: express
-      commands:
-      - cd javascript/express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/express
-    - name: hapi
-      commands:
-      - cd javascript/hapi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/hapi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/hapi
-    - name: muneem
-      commands:
-      - cd javascript/muneem && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/muneem/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/muneem
-    - name: turbo_polka
-      commands:
-      - cd javascript/turbo_polka && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/turbo_polka/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/turbo_polka
-    - name: fyrejet-uwebsockets
-      commands:
-      - cd javascript/fyrejet-uwebsockets && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/fyrejet-uwebsockets/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/fyrejet-uwebsockets
-    - name: nanoexpress
-      commands:
-      - cd javascript/nanoexpress && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nanoexpress/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nanoexpress
-    - name: fyrejet
-      commands:
-      - cd javascript/fyrejet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/fyrejet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/fyrejet
-    - name: feathersjs
-      commands:
-      - cd javascript/feathersjs && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/feathersjs/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/feathersjs
-    - name: low-http-server
-      commands:
-      - cd javascript/low-http-server && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/low-http-server/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/low-http-server
-    - name: iotjs-express
-      commands:
-      - cd javascript/iotjs-express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/iotjs-express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/iotjs-express
-    - name: nestjs-express
-      commands:
-      - cd javascript/nestjs-express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nestjs-express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nestjs-express
-    - name: restify
-      commands:
-      - cd javascript/restify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/restify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/restify
-    - name: polkadot
-      commands:
-      - cd javascript/polkadot && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/polkadot/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/polkadot
-    - name: rayo
-      commands:
-      - cd javascript/rayo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/rayo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/rayo
-    - name: naturaljs-router
-      commands:
-      - cd javascript/naturaljs-router && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/naturaljs-router/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/naturaljs-router
     - name: tinyhttp
       commands:
       - cd javascript/tinyhttp && make build  -f .Makefile  && cd -
@@ -4173,11 +3799,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/tinyhttp
-    - name: sails
+    - name: restana
       commands:
-      - cd javascript/sails && make build  -f .Makefile  && cd -
+      - cd javascript/restana && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f javascript/sails/.Makefile collect
+      - make  -f javascript/restana/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -4189,7 +3815,58 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: javascript/sails
+        value: javascript/restana
+    - name: nestjs-fastify
+      commands:
+      - cd javascript/nestjs-fastify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nestjs-fastify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nestjs-fastify
+    - name: nestjs-express
+      commands:
+      - cd javascript/nestjs-express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nestjs-express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nestjs-express
+    - name: nanoexpress
+      commands:
+      - cd javascript/nanoexpress && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nanoexpress/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nanoexpress
     - name: fastify
       commands:
       - cd javascript/fastify && make build  -f .Makefile  && cd -
@@ -4207,6 +3884,312 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/fastify
+    - name: turbo_polka
+      commands:
+      - cd javascript/turbo_polka && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/turbo_polka/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/turbo_polka
+    - name: sifrr
+      commands:
+      - cd javascript/sifrr && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/sifrr/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/sifrr
+    - name: sails
+      commands:
+      - cd javascript/sails && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/sails/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/sails
+    - name: naturaljs-router
+      commands:
+      - cd javascript/naturaljs-router && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/naturaljs-router/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/naturaljs-router
+    - name: low-http-server
+      commands:
+      - cd javascript/low-http-server && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/low-http-server/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/low-http-server
+    - name: fyrejet
+      commands:
+      - cd javascript/fyrejet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/fyrejet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/fyrejet
+    - name: fyrejet-uwebsockets
+      commands:
+      - cd javascript/fyrejet-uwebsockets && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/fyrejet-uwebsockets/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/fyrejet-uwebsockets
+    - name: 0http
+      commands:
+      - cd javascript/0http && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/0http/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/0http
+    - name: hapi
+      commands:
+      - cd javascript/hapi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/hapi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/hapi
+    - name: restify
+      commands:
+      - cd javascript/restify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/restify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/restify
+    - name: rayo
+      commands:
+      - cd javascript/rayo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/rayo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/rayo
+    - name: polkadot
+      commands:
+      - cd javascript/polkadot && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/polkadot/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/polkadot
+    - name: polka
+      commands:
+      - cd javascript/polka && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/polka/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/polka
+    - name: muneem
+      commands:
+      - cd javascript/muneem && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/muneem/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/muneem
+    - name: iotjs-express
+      commands:
+      - cd javascript/iotjs-express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/iotjs-express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/iotjs-express
+    - name: foxify
+      commands:
+      - cd javascript/foxify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/foxify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/foxify
+    - name: feathersjs
+      commands:
+      - cd javascript/feathersjs && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/feathersjs/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/feathersjs
+    - name: express
+      commands:
+      - cd javascript/express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/express
     - name: koa
       commands:
       - cd javascript/koa && make build  -f .Makefile  && cd -
@@ -4224,6 +4207,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/koa
+    - name: moleculer
+      commands:
+      - cd javascript/moleculer && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/moleculer/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/moleculer
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -4300,6 +4300,57 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
+    - name: roda
+      commands:
+      - cd ruby/roda && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/roda/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/roda
+    - name: rack-routing
+      commands:
+      - cd ruby/rack-routing && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/rack-routing/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/rack-routing
+    - name: agoo
+      commands:
+      - cd ruby/agoo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/agoo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/agoo
     - name: syro
       commands:
       - cd ruby/syro && make build  -f .Makefile  && cd -
@@ -4334,6 +4385,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/sinatra
+    - name: rails
+      commands:
+      - cd ruby/rails && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/rails/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/rails
     - name: rack_app
       commands:
       - cd ruby/rack_app && make build  -f .Makefile  && cd -
@@ -4351,74 +4419,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/rack_app
-    - name: camping
-      commands:
-      - cd ruby/camping && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/camping/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/camping
-    - name: roda
-      commands:
-      - cd ruby/roda && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/roda/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/roda
-    - name: agoo
-      commands:
-      - cd ruby/agoo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/agoo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/agoo
-    - name: rack-routing
-      commands:
-      - cd ruby/rack-routing && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/rack-routing/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/rack-routing
     - name: hanami-api
       commands:
       - cd ruby/hanami-api && make build  -f .Makefile  && cd -
@@ -4470,11 +4470,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/cuba
-    - name: rails
+    - name: camping
       commands:
-      - cd ruby/rails && make build  -f .Makefile  && cd -
+      - cd ruby/camping && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f ruby/rails/.Makefile collect
+      - make  -f ruby/camping/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -4486,7 +4486,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: ruby/rails
+        value: ruby/camping
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,193 +85,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: chi
-      commands:
-      - cd go/chi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/chi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/chi
-    - name: violetear
-      commands:
-      - cd go/violetear && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/violetear/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/violetear
-    - name: httprouter
-      commands:
-      - cd go/httprouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/httprouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/httprouter
-    - name: macaron
-      commands:
-      - cd go/macaron && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/macaron/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/macaron
-    - name: gramework
-      commands:
-      - cd go/gramework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gramework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gramework
-    - name: gearbox
-      commands:
-      - cd go/gearbox && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gearbox/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gearbox
-    - name: fasthttp
-      commands:
-      - cd go/fasthttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/fasthttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/fasthttp
-    - name: gf
-      commands:
-      - cd go/gf && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gf/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gf
-    - name: echo
-      commands:
-      - cd go/echo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/echo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/echo
-    - name: gorouter
-      commands:
-      - cd go/gorouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorouter
-    - name: apirouter
-      commands:
-      - cd go/apirouter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/apirouter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/apirouter
     - name: goyave
       commands:
       - cd go/goyave && make build  -f .Makefile  && cd -
@@ -289,11 +102,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/goyave
-    - name: atreugo
+    - name: fasthttp
       commands:
-      - cd go/atreugo && make build  -f .Makefile  && cd -
+      - cd go/fasthttp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f go/atreugo/.Makefile collect
+      - make  -f go/fasthttp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -305,7 +118,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: go/atreugo
+        value: go/fasthttp
+    - name: apirouter
+      commands:
+      - cd go/apirouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/apirouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/apirouter
     - name: kami
       commands:
       - cd go/kami && make build  -f .Makefile  && cd -
@@ -323,40 +153,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/kami
-    - name: aero
-      commands:
-      - cd go/aero && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/aero/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/aero
-    - name: air
-      commands:
-      - cd go/air && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/air/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/air
     - name: tango
       commands:
       - cd go/tango && make build  -f .Makefile  && cd -
@@ -374,11 +170,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/tango
-    - name: goroute
+    - name: gramework
       commands:
-      - cd go/goroute && make build  -f .Makefile  && cd -
+      - cd go/gramework && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f go/goroute/.Makefile collect
+      - make  -f go/gramework/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -390,58 +186,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: go/goroute
-    - name: beego
-      commands:
-      - cd go/beego && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/beego/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/beego
-    - name: gorouter-fasthttp
-      commands:
-      - cd go/gorouter-fasthttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorouter-fasthttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorouter-fasthttp
-    - name: fiber
-      commands:
-      - cd go/fiber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/fiber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/fiber
+        value: go/gramework
     - name: rte
       commands:
       - cd go/rte && make build  -f .Makefile  && cd -
@@ -459,74 +204,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/rte
-    - name: clevergo
-      commands:
-      - cd go/clevergo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/clevergo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/clevergo
-    - name: gorilla-mux
-      commands:
-      - cd go/gorilla-mux && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gorilla-mux/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gorilla-mux
-    - name: mars
-      commands:
-      - cd go/mars && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/mars/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/mars
-    - name: gin
-      commands:
-      - cd go/gin && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f go/gin/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: go/gin
     - name: webgo
       commands:
       - cd go/webgo && make build  -f .Makefile  && cd -
@@ -561,6 +238,329 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: go/router
+    - name: mars
+      commands:
+      - cd go/mars && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/mars/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/mars
+    - name: gf
+      commands:
+      - cd go/gf && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gf/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gf
+    - name: fiber
+      commands:
+      - cd go/fiber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/fiber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/fiber
+    - name: echo
+      commands:
+      - cd go/echo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/echo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/echo
+    - name: clevergo
+      commands:
+      - cd go/clevergo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/clevergo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/clevergo
+    - name: beego
+      commands:
+      - cd go/beego && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/beego/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/beego
+    - name: atreugo
+      commands:
+      - cd go/atreugo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/atreugo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/atreugo
+    - name: air
+      commands:
+      - cd go/air && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/air/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/air
+    - name: macaron
+      commands:
+      - cd go/macaron && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/macaron/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/macaron
+    - name: gin
+      commands:
+      - cd go/gin && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gin/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gin
+    - name: gearbox
+      commands:
+      - cd go/gearbox && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gearbox/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gearbox
+    - name: chi
+      commands:
+      - cd go/chi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/chi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/chi
+    - name: violetear
+      commands:
+      - cd go/violetear && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/violetear/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/violetear
+    - name: gorouter
+      commands:
+      - cd go/gorouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorouter
+    - name: gorouter-fasthttp
+      commands:
+      - cd go/gorouter-fasthttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorouter-fasthttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorouter-fasthttp
+    - name: goroute
+      commands:
+      - cd go/goroute && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/goroute/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/goroute
+    - name: gorilla-mux
+      commands:
+      - cd go/gorilla-mux && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/gorilla-mux/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/gorilla-mux
+    - name: httprouter
+      commands:
+      - cd go/httprouter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/httprouter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/httprouter
+    - name: aero
+      commands:
+      - cd go/aero && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f go/aero/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: go/aero
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -584,57 +584,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: mike
-      commands:
-      - cd nim/mike && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/mike/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/mike
-    - name: prologue
-      commands:
-      - cd nim/prologue && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/prologue/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/prologue
-    - name: akane
-      commands:
-      - cd nim/akane && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f nim/akane/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: nim/akane
     - name: httpbeast
       commands:
       - cd nim/httpbeast && make build  -f .Makefile  && cd -
@@ -652,6 +601,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/httpbeast
+    - name: akane
+      commands:
+      - cd nim/akane && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/akane/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/akane
     - name: scorper
       commands:
       - cd nim/scorper && make build  -f .Makefile  && cd -
@@ -669,11 +635,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/scorper
-    - name: jester
+    - name: prologue
       commands:
-      - cd nim/jester && make build  -f .Makefile  && cd -
+      - cd nim/prologue && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f nim/jester/.Makefile collect
+      - make  -f nim/prologue/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -685,7 +651,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: nim/jester
+        value: nim/prologue
+    - name: mike
+      commands:
+      - cd nim/mike && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/mike/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/mike
     - name: whip
       commands:
       - cd nim/whip && make build  -f .Makefile  && cd -
@@ -720,6 +703,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: nim/rosencrantz
+    - name: jester
+      commands:
+      - cd nim/jester && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f nim/jester/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: nim/jester
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -743,40 +743,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: flask
-      commands:
-      - cd python/flask && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/flask/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/flask
-    - name: aiohttp
-      commands:
-      - cd python/aiohttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/aiohttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/aiohttp
     - name: apidaora
       commands:
       - cd python/apidaora && make build  -f .Makefile  && cd -
@@ -794,40 +760,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/apidaora
-    - name: masonite
-      commands:
-      - cd python/masonite && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/masonite/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/masonite
-    - name: clastic
-      commands:
-      - cd python/clastic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/clastic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/clastic
     - name: guillotina
       commands:
       - cd python/guillotina && make build  -f .Makefile  && cd -
@@ -845,6 +777,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/guillotina
+    - name: flask
+      commands:
+      - cd python/flask && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/flask/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/flask
     - name: index.py
       commands:
       - cd python/index.py && make build  -f .Makefile  && cd -
@@ -879,6 +828,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/quart
+    - name: clastic
+      commands:
+      - cd python/clastic && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/clastic/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/clastic
+    - name: masonite
+      commands:
+      - cd python/masonite && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/masonite/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/masonite
+    - name: cherrypy
+      commands:
+      - cd python/cherrypy && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/cherrypy/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/cherrypy
     - name: pyramid
       commands:
       - cd python/pyramid && make build  -f .Makefile  && cd -
@@ -913,227 +913,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/starlette
-    - name: cherrypy
-      commands:
-      - cd python/cherrypy && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/cherrypy/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/cherrypy
-    - name: emmett
-      commands:
-      - cd python/emmett && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/emmett/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/emmett
-    - name: hug
-      commands:
-      - cd python/hug && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/hug/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/hug
-    - name: blacksheep
-      commands:
-      - cd python/blacksheep && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/blacksheep/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/blacksheep
-    - name: baize-wsgi
-      commands:
-      - cd python/baize-wsgi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/baize-wsgi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/baize-wsgi
-    - name: molten
-      commands:
-      - cd python/molten && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/molten/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/molten
-    - name: tornado
-      commands:
-      - cd python/tornado && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/tornado/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/tornado
-    - name: tonberry
-      commands:
-      - cd python/tonberry && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/tonberry/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/tonberry
-    - name: nameko
-      commands:
-      - cd python/nameko && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/nameko/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/nameko
-    - name: fastapi
-      commands:
-      - cd python/fastapi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/fastapi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/fastapi
-    - name: klein
-      commands:
-      - cd python/klein && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/klein/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/klein
-    - name: sanic
-      commands:
-      - cd python/sanic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/sanic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/sanic
-    - name: responder
-      commands:
-      - cd python/responder && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f python/responder/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: python/responder
     - name: asgineer
       commands:
       - cd python/asgineer && make build  -f .Makefile  && cd -
@@ -1151,11 +930,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/asgineer
-    - name: django-ninja
+    - name: emmett
       commands:
-      - cd python/django-ninja && make build  -f .Makefile  && cd -
+      - cd python/emmett && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/django-ninja/.Makefile collect
+      - make  -f python/emmett/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1167,12 +946,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/django-ninja
-    - name: baize-asgi
+        value: python/emmett
+    - name: baize-wsgi
       commands:
-      - cd python/baize-asgi && make build  -f .Makefile  && cd -
+      - cd python/baize-wsgi && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/baize-asgi/.Makefile collect
+      - make  -f python/baize-wsgi/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1184,12 +963,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/baize-asgi
-    - name: cyclone
+        value: python/baize-wsgi
+    - name: blacksheep
       commands:
-      - cd python/cyclone && make build  -f .Makefile  && cd -
+      - cd python/blacksheep && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/cyclone/.Makefile collect
+      - make  -f python/blacksheep/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1201,12 +980,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/cyclone
-    - name: django
+        value: python/blacksheep
+    - name: hug
       commands:
-      - cd python/django && make build  -f .Makefile  && cd -
+      - cd python/hug && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f python/django/.Makefile collect
+      - make  -f python/hug/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -1218,7 +997,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: python/django
+        value: python/hug
+    - name: aiohttp
+      commands:
+      - cd python/aiohttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/aiohttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/aiohttp
     - name: falcon
       commands:
       - cd python/falcon && make build  -f .Makefile  && cd -
@@ -1236,6 +1032,125 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/falcon
+    - name: molten
+      commands:
+      - cd python/molten && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/molten/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/molten
+    - name: tonberry
+      commands:
+      - cd python/tonberry && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/tonberry/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/tonberry
+    - name: klein
+      commands:
+      - cd python/klein && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/klein/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/klein
+    - name: fastapi
+      commands:
+      - cd python/fastapi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/fastapi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/fastapi
+    - name: responder
+      commands:
+      - cd python/responder && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/responder/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/responder
+    - name: django-ninja
+      commands:
+      - cd python/django-ninja && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/django-ninja/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/django-ninja
+    - name: django
+      commands:
+      - cd python/django && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/django/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/django
     - name: bottle
       commands:
       - cd python/bottle && make build  -f .Makefile  && cd -
@@ -1253,6 +1168,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: python/bottle
+    - name: baize-asgi
+      commands:
+      - cd python/baize-asgi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/baize-asgi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/baize-asgi
+    - name: sanic
+      commands:
+      - cd python/sanic && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/sanic/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/sanic
+    - name: cyclone
+      commands:
+      - cd python/cyclone && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/cyclone/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/cyclone
+    - name: tornado
+      commands:
+      - cd python/tornado && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/tornado/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/tornado
+    - name: nameko
+      commands:
+      - cd python/nameko && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f python/nameko/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: python/nameko
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1293,6 +1293,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: clojure/donkey
+    - name: luminus
+      commands:
+      - cd clojure/luminus && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f clojure/luminus/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: clojure/luminus
     - name: yada
       commands:
       - cd clojure/yada && make build  -f .Makefile  && cd -
@@ -1327,23 +1344,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: clojure/coast
-    - name: luminus
-      commands:
-      - cd clojure/luminus && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f clojure/luminus/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: clojure/luminus
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1367,57 +1367,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: cowboy
-      commands:
-      - cd elixir/cowboy && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/cowboy/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/cowboy
-    - name: cowboy_stream
-      commands:
-      - cd elixir/cowboy_stream && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/cowboy_stream/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/cowboy_stream
-    - name: phoenix
-      commands:
-      - cd elixir/phoenix && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f elixir/phoenix/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: elixir/phoenix
     - name: plug
       commands:
       - cd elixir/plug && make build  -f .Makefile  && cd -
@@ -1435,6 +1384,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: elixir/plug
+    - name: cowboy_stream
+      commands:
+      - cd elixir/cowboy_stream && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/cowboy_stream/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/cowboy_stream
+    - name: cowboy
+      commands:
+      - cd elixir/cowboy && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/cowboy/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/cowboy
+    - name: phoenix
+      commands:
+      - cd elixir/phoenix && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f elixir/phoenix/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: elixir/phoenix
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1538,57 +1538,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: gotham
-      commands:
-      - cd rust/gotham && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/gotham/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/gotham
-    - name: iron
-      commands:
-      - cd rust/iron && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/iron/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/iron
-    - name: nickel
-      commands:
-      - cd rust/nickel && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f rust/nickel/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: rust/nickel
     - name: salvo
       commands:
       - cd rust/salvo && make build  -f .Makefile  && cd -
@@ -1606,6 +1555,40 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: rust/salvo
+    - name: iron
+      commands:
+      - cd rust/iron && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/iron/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/iron
+    - name: gotham
+      commands:
+      - cd rust/gotham && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/gotham/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/gotham
     - name: actix
       commands:
       - cd rust/actix && make build  -f .Makefile  && cd -
@@ -1623,6 +1606,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: rust/actix
+    - name: nickel
+      commands:
+      - cd rust/nickel && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f rust/nickel/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: rust/nickel
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1646,91 +1646,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: giraffe
-      commands:
-      - cd fsharp/giraffe && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/giraffe/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/giraffe
-    - name: websharper
-      commands:
-      - cd fsharp/websharper && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/websharper/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/websharper
-    - name: saturn
-      commands:
-      - cd fsharp/saturn && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/saturn/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/saturn
-    - name: frank
-      commands:
-      - cd fsharp/frank && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/frank/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/frank
-    - name: suave
-      commands:
-      - cd fsharp/suave && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f fsharp/suave/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: fsharp/suave
     - name: falco
       commands:
       - cd fsharp/falco && make build  -f .Makefile  && cd -
@@ -1748,6 +1663,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: fsharp/falco
+    - name: websharper
+      commands:
+      - cd fsharp/websharper && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/websharper/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/websharper
+    - name: suave
+      commands:
+      - cd fsharp/suave && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/suave/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/suave
+    - name: frank
+      commands:
+      - cd fsharp/frank && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/frank/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/frank
+    - name: saturn
+      commands:
+      - cd fsharp/saturn && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/saturn/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/saturn
+    - name: giraffe
+      commands:
+      - cd fsharp/giraffe && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f fsharp/giraffe/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: fsharp/giraffe
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1771,40 +1771,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: plumber
-      commands:
-      - cd r/plumber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f r/plumber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: r/plumber
-    - name: restrserve
-      commands:
-      - cd r/restrserve && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f r/restrserve/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: r/restrserve
     - name: rserve
       commands:
       - cd r/rserve && make build  -f .Makefile  && cd -
@@ -1822,6 +1788,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: r/rserve
+    - name: restrserve
+      commands:
+      - cd r/restrserve && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f r/restrserve/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: r/restrserve
     - name: httpuv
       commands:
       - cd r/httpuv && make build  -f .Makefile  && cd -
@@ -1839,6 +1822,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: r/httpuv
+    - name: plumber
+      commands:
+      - cd r/plumber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f r/plumber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: r/plumber
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -1862,244 +1862,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: quarkus
-      commands:
-      - cd java/quarkus && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/quarkus/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/quarkus
-    - name: restheart
-      commands:
-      - cd java/restheart && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/restheart/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/restheart
-    - name: light-4j
-      commands:
-      - cd java/light-4j && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/light-4j/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/light-4j
-    - name: vertx
-      commands:
-      - cd java/vertx && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/vertx/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/vertx
-    - name: jooby
-      commands:
-      - cd java/jooby && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jooby/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jooby
-    - name: activej
-      commands:
-      - cd java/activej && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/activej/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/activej
-    - name: jersey-grizzly2
-      commands:
-      - cd java/jersey-grizzly2 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jersey-grizzly2/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jersey-grizzly2
-    - name: javalin
-      commands:
-      - cd java/javalin && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/javalin/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/javalin
-    - name: jersey3-grizzly2
-      commands:
-      - cd java/jersey3-grizzly2 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/jersey3-grizzly2/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/jersey3-grizzly2
-    - name: act
-      commands:
-      - cd java/act && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/act/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/act
-    - name: rapidoid
-      commands:
-      - cd java/rapidoid && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/rapidoid/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/rapidoid
-    - name: vertx4web
-      commands:
-      - cd java/vertx4web && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/vertx4web/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/vertx4web
-    - name: undertow
-      commands:
-      - cd java/undertow && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/undertow/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/undertow
-    - name: blade
-      commands:
-      - cd java/blade && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f java/blade/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: java/blade
     - name: struts2
       commands:
       - cd java/struts2 && make build  -f .Makefile  && cd -
@@ -2117,11 +1879,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: java/struts2
-    - name: micronaut
+    - name: quarkus
       commands:
-      - cd java/micronaut && make build  -f .Makefile  && cd -
+      - cd java/quarkus && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f java/micronaut/.Makefile collect
+      - make  -f java/quarkus/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2133,12 +1895,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: java/micronaut
-    - name: spark
+        value: java/quarkus
+    - name: vertx4web
       commands:
-      - cd java/spark && make build  -f .Makefile  && cd -
+      - cd java/vertx4web && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f java/spark/.Makefile collect
+      - make  -f java/vertx4web/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2150,7 +1912,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: java/spark
+        value: java/vertx4web
+    - name: vertx
+      commands:
+      - cd java/vertx && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/vertx/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/vertx
     - name: spring
       commands:
       - cd java/spring && make build  -f .Makefile  && cd -
@@ -2168,6 +1947,227 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: java/spring
+    - name: restheart
+      commands:
+      - cd java/restheart && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/restheart/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/restheart
+    - name: jooby
+      commands:
+      - cd java/jooby && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jooby/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jooby
+    - name: jersey-grizzly2
+      commands:
+      - cd java/jersey-grizzly2 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jersey-grizzly2/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jersey-grizzly2
+    - name: activej
+      commands:
+      - cd java/activej && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/activej/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/activej
+    - name: undertow
+      commands:
+      - cd java/undertow && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/undertow/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/undertow
+    - name: spark
+      commands:
+      - cd java/spark && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/spark/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/spark
+    - name: rapidoid
+      commands:
+      - cd java/rapidoid && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/rapidoid/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/rapidoid
+    - name: micronaut
+      commands:
+      - cd java/micronaut && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/micronaut/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/micronaut
+    - name: light-4j
+      commands:
+      - cd java/light-4j && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/light-4j/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/light-4j
+    - name: jersey3-grizzly2
+      commands:
+      - cd java/jersey3-grizzly2 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/jersey3-grizzly2/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/jersey3-grizzly2
+    - name: javalin
+      commands:
+      - cd java/javalin && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/javalin/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/javalin
+    - name: act
+      commands:
+      - cd java/act && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/act/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/act
+    - name: blade
+      commands:
+      - cd java/blade && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f java/blade/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: java/blade
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2191,6 +2191,23 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
+    - name: ktor
+      commands:
+      - cd kotlin/ktor && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f kotlin/ktor/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: kotlin/ktor
     - name: kooby
       commands:
       - cd kotlin/kooby && make build  -f .Makefile  && cd -
@@ -2225,23 +2242,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: kotlin/http4k
-    - name: ktor
-      commands:
-      - cd kotlin/ktor && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f kotlin/ktor/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: kotlin/ktor
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2265,108 +2265,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: shivneri
-      commands:
-      - cd crystal/shivneri && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/shivneri/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/shivneri
-    - name: orion
-      commands:
-      - cd crystal/orion && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/orion/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/orion
-    - name: amber
-      commands:
-      - cd crystal/amber && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/amber/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/amber
-    - name: router.cr
-      commands:
-      - cd crystal/router.cr && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/router.cr/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/router.cr
-    - name: runcobo
-      commands:
-      - cd crystal/runcobo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/runcobo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/runcobo
-    - name: toro
-      commands:
-      - cd crystal/toro && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f crystal/toro/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: crystal/toro
     - name: spider-gazelle
       commands:
       - cd crystal/spider-gazelle && make build  -f .Makefile  && cd -
@@ -2384,11 +2282,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: crystal/spider-gazelle
-    - name: grip
+    - name: shivneri
       commands:
-      - cd crystal/grip && make build  -f .Makefile  && cd -
+      - cd crystal/shivneri && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f crystal/grip/.Makefile collect
+      - make  -f crystal/shivneri/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2400,7 +2298,24 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: crystal/grip
+        value: crystal/shivneri
+    - name: runcobo
+      commands:
+      - cd crystal/runcobo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/runcobo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/runcobo
     - name: kemal
       commands:
       - cd crystal/kemal && make build  -f .Makefile  && cd -
@@ -2435,6 +2350,91 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: crystal/athena
+    - name: amber
+      commands:
+      - cd crystal/amber && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/amber/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/amber
+    - name: grip
+      commands:
+      - cd crystal/grip && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/grip/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/grip
+    - name: toro
+      commands:
+      - cd crystal/toro && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/toro/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/toro
+    - name: router.cr
+      commands:
+      - cd crystal/router.cr && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/router.cr/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/router.cr
+    - name: orion
+      commands:
+      - cd crystal/orion && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f crystal/orion/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: crystal/orion
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2458,23 +2458,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: scotty
-      commands:
-      - cd haskell/scotty && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f haskell/scotty/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: haskell/scotty
     - name: servant
       commands:
       - cd haskell/servant && make build  -f .Makefile  && cd -
@@ -2492,6 +2475,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: haskell/servant
+    - name: scotty
+      commands:
+      - cd haskell/scotty && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f haskell/scotty/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: haskell/scotty
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -2515,11 +2515,11 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: slim-swoole
+    - name: mixphp
       commands:
-      - cd php/slim-swoole && make build  -f .Makefile  && cd -
+      - cd php/mixphp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/slim-swoole/.Makefile collect
+      - make  -f php/mixphp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2531,12 +2531,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/slim-swoole
-    - name: chubbyphp-swoole
+        value: php/mixphp
+    - name: mixphp-workerman
       commands:
-      - cd php/chubbyphp-swoole && make build  -f .Makefile  && cd -
+      - cd php/mixphp-workerman && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/chubbyphp-swoole/.Makefile collect
+      - make  -f php/mixphp-workerman/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2548,12 +2548,12 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/chubbyphp-swoole
-    - name: sunrise-router-roadrunner
+        value: php/mixphp-workerman
+    - name: mixphp-swoole
       commands:
-      - cd php/sunrise-router-roadrunner && make build  -f .Makefile  && cd -
+      - cd php/mixphp-swoole && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/sunrise-router-roadrunner/.Makefile collect
+      - make  -f php/mixphp-swoole/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -2565,755 +2565,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/sunrise-router-roadrunner
-    - name: cubex
-      commands:
-      - cd php/cubex && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/cubex/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/cubex
-    - name: swoole
-      commands:
-      - cd php/swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoole
-    - name: slim-roadrunner
-      commands:
-      - cd php/slim-roadrunner && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/slim-roadrunner/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/slim-roadrunner
-    - name: swoft
-      commands:
-      - cd php/swoft && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoft/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoft
-    - name: simps
-      commands:
-      - cd php/simps && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/simps/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/simps
-    - name: nano
-      commands:
-      - cd php/nano && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/nano/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/nano
-    - name: codeigniter4
-      commands:
-      - cd php/codeigniter4 && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/codeigniter4/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/codeigniter4
-    - name: yii
-      commands:
-      - cd php/yii && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/yii/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/yii
-    - name: phalcon
-      commands:
-      - cd php/phalcon && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/phalcon/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/phalcon
-    - name: one-fpm
-      commands:
-      - cd php/one-fpm && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/one-fpm/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/one-fpm
-    - name: ice
-      commands:
-      - cd php/ice && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/ice/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/ice
-    - name: spiral
-      commands:
-      - cd php/spiral && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/spiral/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/spiral
-    - name: mark
-      commands:
-      - cd php/mark && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mark/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mark
-    - name: siler-swoole
-      commands:
-      - cd php/siler-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/siler-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/siler-swoole
-    - name: workerman
-      commands:
-      - cd php/workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/workerman
-    - name: chubbyphp-roadrunner
-      commands:
-      - cd php/chubbyphp-roadrunner && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp-roadrunner/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp-roadrunner
-    - name: nette
-      commands:
-      - cd php/nette && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/nette/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/nette
-    - name: webman
-      commands:
-      - cd php/webman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/webman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/webman
-    - name: driftphp
-      commands:
-      - cd php/driftphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/driftphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/driftphp
-    - name: sw-fw-less
-      commands:
-      - cd php/sw-fw-less && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sw-fw-less/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sw-fw-less
-    - name: laminas
-      commands:
-      - cd php/laminas && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/laminas/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/laminas
-    - name: chubbyphp
-      commands:
-      - cd php/chubbyphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp
-    - name: imi
-      commands:
-      - cd php/imi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/imi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/imi
-    - name: unic
-      commands:
-      - cd php/unic && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/unic/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/unic
-    - name: basicphp
-      commands:
-      - cd php/basicphp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/basicphp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/basicphp
-    - name: comet
-      commands:
-      - cd php/comet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/comet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/comet
-    - name: sunrise-router
-      commands:
-      - cd php/sunrise-router && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sunrise-router/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sunrise-router
-    - name: ubiquity
-      commands:
-      - cd php/ubiquity && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/ubiquity/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/ubiquity
-    - name: one
-      commands:
-      - cd php/one && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/one/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/one
-    - name: mezzio
-      commands:
-      - cd php/mezzio && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/mezzio/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/mezzio
-    - name: lumen
-      commands:
-      - cd php/lumen && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/lumen/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/lumen
-    - name: antidot
-      commands:
-      - cd php/antidot && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/antidot/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/antidot
-    - name: siler
-      commands:
-      - cd php/siler && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/siler/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/siler
-    - name: fastsitephp
-      commands:
-      - cd php/fastsitephp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/fastsitephp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/fastsitephp
-    - name: bearframework
-      commands:
-      - cd php/bearframework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/bearframework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/bearframework
-    - name: laravel-s-laravel
-      commands:
-      - cd php/laravel-s-laravel && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/laravel-s-laravel/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/laravel-s-laravel
-    - name: hamlet
-      commands:
-      - cd php/hamlet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/hamlet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/hamlet
-    - name: swoole-coroutine
-      commands:
-      - cd php/swoole-coroutine && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/swoole-coroutine/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/swoole-coroutine
-    - name: symfony
-      commands:
-      - cd php/symfony && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/symfony/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/symfony
-    - name: slim
-      commands:
-      - cd php/slim && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/slim/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/slim
-    - name: chubbyphp-workerman
-      commands:
-      - cd php/chubbyphp-workerman && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/chubbyphp-workerman/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/chubbyphp-workerman
-    - name: sunrise-router-annotations
-      commands:
-      - cd php/sunrise-router-annotations && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/sunrise-router-annotations/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/sunrise-router-annotations
-    - name: yii-swoole
-      commands:
-      - cd php/yii-swoole && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/yii-swoole/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/yii-swoole
-    - name: fatfree
-      commands:
-      - cd php/fatfree && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f php/fatfree/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: php/fatfree
+        value: php/mixphp-swoole
     - name: laravel
       commands:
       - cd php/laravel && make build  -f .Makefile  && cd -
@@ -3331,11 +2583,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/laravel
-    - name: hyperf
+    - name: driftphp
       commands:
-      - cd php/hyperf && make build  -f .Makefile  && cd -
+      - cd php/driftphp && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f php/hyperf/.Makefile collect
+      - make  -f php/driftphp/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -3347,7 +2599,279 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: php/hyperf
+        value: php/driftphp
+    - name: workerman
+      commands:
+      - cd php/workerman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/workerman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/workerman
+    - name: webman
+      commands:
+      - cd php/webman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/webman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/webman
+    - name: symfony
+      commands:
+      - cd php/symfony && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/symfony/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/symfony
+    - name: swoole
+      commands:
+      - cd php/swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoole
+    - name: swoole-coroutine
+      commands:
+      - cd php/swoole-coroutine && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoole-coroutine/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoole-coroutine
+    - name: sunrise-router
+      commands:
+      - cd php/sunrise-router && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router
+    - name: sunrise-router-roadrunner
+      commands:
+      - cd php/sunrise-router-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router-roadrunner
+    - name: sunrise-router-annotations
+      commands:
+      - cd php/sunrise-router-annotations && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sunrise-router-annotations/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sunrise-router-annotations
+    - name: spiral
+      commands:
+      - cd php/spiral && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/spiral/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/spiral
+    - name: slim
+      commands:
+      - cd php/slim && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim
+    - name: slim-swoole
+      commands:
+      - cd php/slim-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim-swoole
+    - name: slim-roadrunner
+      commands:
+      - cd php/slim-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/slim-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/slim-roadrunner
+    - name: phalcon
+      commands:
+      - cd php/phalcon && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/phalcon/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/phalcon
+    - name: nano
+      commands:
+      - cd php/nano && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/nano/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/nano
+    - name: mezzio
+      commands:
+      - cd php/mezzio && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/mezzio/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/mezzio
+    - name: mark
+      commands:
+      - cd php/mark && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/mark/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/mark
     - name: laravel-s-lumen
       commands:
       - cd php/laravel-s-lumen && make build  -f .Makefile  && cd -
@@ -3365,6 +2889,482 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: php/laravel-s-lumen
+    - name: laravel-s-laravel
+      commands:
+      - cd php/laravel-s-laravel && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/laravel-s-laravel/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/laravel-s-laravel
+    - name: imi
+      commands:
+      - cd php/imi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/imi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/imi
+    - name: ice
+      commands:
+      - cd php/ice && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/ice/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/ice
+    - name: hyperf
+      commands:
+      - cd php/hyperf && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/hyperf/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/hyperf
+    - name: hamlet
+      commands:
+      - cd php/hamlet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/hamlet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/hamlet
+    - name: comet
+      commands:
+      - cd php/comet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/comet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/comet
+    - name: codeigniter4
+      commands:
+      - cd php/codeigniter4 && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/codeigniter4/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/codeigniter4
+    - name: chubbyphp
+      commands:
+      - cd php/chubbyphp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp
+    - name: chubbyphp-workerman
+      commands:
+      - cd php/chubbyphp-workerman && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-workerman/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-workerman
+    - name: chubbyphp-swoole
+      commands:
+      - cd php/chubbyphp-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-swoole
+    - name: chubbyphp-roadrunner
+      commands:
+      - cd php/chubbyphp-roadrunner && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/chubbyphp-roadrunner/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/chubbyphp-roadrunner
+    - name: antidot
+      commands:
+      - cd php/antidot && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/antidot/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/antidot
+    - name: yii
+      commands:
+      - cd php/yii && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/yii/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/yii
+    - name: yii-swoole
+      commands:
+      - cd php/yii-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/yii-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/yii-swoole
+    - name: ubiquity
+      commands:
+      - cd php/ubiquity && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/ubiquity/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/ubiquity
+    - name: swoft
+      commands:
+      - cd php/swoft && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/swoft/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/swoft
+    - name: sw-fw-less
+      commands:
+      - cd php/sw-fw-less && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/sw-fw-less/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/sw-fw-less
+    - name: simps
+      commands:
+      - cd php/simps && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/simps/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/simps
+    - name: siler
+      commands:
+      - cd php/siler && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/siler/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/siler
+    - name: siler-swoole
+      commands:
+      - cd php/siler-swoole && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/siler-swoole/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/siler-swoole
+    - name: one
+      commands:
+      - cd php/one && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/one/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/one
+    - name: one-fpm
+      commands:
+      - cd php/one-fpm && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/one-fpm/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/one-fpm
+    - name: nette
+      commands:
+      - cd php/nette && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/nette/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/nette
+    - name: lumen
+      commands:
+      - cd php/lumen && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/lumen/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/lumen
+    - name: laminas
+      commands:
+      - cd php/laminas && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/laminas/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/laminas
+    - name: cubex
+      commands:
+      - cd php/cubex && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/cubex/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/cubex
+    - name: bearframework
+      commands:
+      - cd php/bearframework && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/bearframework/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/bearframework
+    - name: basicphp
+      commands:
+      - cd php/basicphp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f php/basicphp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: php/basicphp
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3388,40 +3388,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: akkahttp
-      commands:
-      - cd scala/akkahttp && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/akkahttp/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/akkahttp
-    - name: finch
-      commands:
-      - cd scala/finch && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/finch/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/finch
     - name: finatra
       commands:
       - cd scala/finatra && make build  -f .Makefile  && cd -
@@ -3439,23 +3405,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: scala/finatra
-    - name: play
-      commands:
-      - cd scala/play && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f scala/play/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: scala/play
     - name: http4s
       commands:
       - cd scala/http4s && make build  -f .Makefile  && cd -
@@ -3473,6 +3422,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: scala/http4s
+    - name: finch
+      commands:
+      - cd scala/finch && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/finch/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/finch
+    - name: akkahttp
+      commands:
+      - cd scala/akkahttp && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/akkahttp/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/akkahttp
+    - name: play
+      commands:
+      - cd scala/play && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f scala/play/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: scala/play
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3513,23 +3513,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: cpp/nawa
-    - name: drogon
-      commands:
-      - cd cpp/drogon && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f cpp/drogon/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: cpp/drogon
     - name: evhtp
       commands:
       - cd cpp/evhtp && make build  -f .Makefile  && cd -
@@ -3547,6 +3530,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: cpp/evhtp
+    - name: drogon
+      commands:
+      - cd cpp/drogon && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f cpp/drogon/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: cpp/drogon
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3570,40 +3570,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: swifter-framework
-      commands:
-      - cd swift/swifter-framework && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/swifter-framework/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/swifter-framework
-    - name: perfect
-      commands:
-      - cd swift/perfect && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/perfect/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/perfect
     - name: hummingbird-framework
       commands:
       - cd swift/hummingbird-framework && make build  -f .Makefile  && cd -
@@ -3621,23 +3587,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: swift/hummingbird-framework
-    - name: kitura-nio
-      commands:
-      - cd swift/kitura-nio && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f swift/kitura-nio/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: swift/kitura-nio
     - name: vapor-framework
       commands:
       - cd swift/vapor-framework && make build  -f .Makefile  && cd -
@@ -3672,6 +3621,57 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: swift/kitura
+    - name: kitura-nio
+      commands:
+      - cd swift/kitura-nio && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/kitura-nio/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/kitura-nio
+    - name: swifter-framework
+      commands:
+      - cd swift/swifter-framework && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/swifter-framework/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/swifter-framework
+    - name: perfect
+      commands:
+      - cd swift/perfect && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f swift/perfect/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: swift/perfect
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3695,40 +3695,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: aspnetcore
-      commands:
-      - cd csharp/aspnetcore && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f csharp/aspnetcore/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: csharp/aspnetcore
-    - name: carter
-      commands:
-      - cd csharp/carter && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f csharp/carter/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: csharp/carter
     - name: beetlex
       commands:
       - cd csharp/beetlex && make build  -f .Makefile  && cd -
@@ -3763,6 +3729,40 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: csharp/simplify.web
+    - name: carter
+      commands:
+      - cd csharp/carter && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f csharp/carter/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: csharp/carter
+    - name: aspnetcore
+      commands:
+      - cd csharp/aspnetcore && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f csharp/aspnetcore/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: csharp/aspnetcore
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -3826,380 +3826,6 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
-    - name: moleculer
-      commands:
-      - cd javascript/moleculer && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/moleculer/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/moleculer
-    - name: polka
-      commands:
-      - cd javascript/polka && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/polka/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/polka
-    - name: foxify
-      commands:
-      - cd javascript/foxify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/foxify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/foxify
-    - name: 0http
-      commands:
-      - cd javascript/0http && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/0http/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/0http
-    - name: sifrr
-      commands:
-      - cd javascript/sifrr && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/sifrr/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/sifrr
-    - name: nestjs-fastify
-      commands:
-      - cd javascript/nestjs-fastify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nestjs-fastify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nestjs-fastify
-    - name: restana
-      commands:
-      - cd javascript/restana && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/restana/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/restana
-    - name: express
-      commands:
-      - cd javascript/express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/express
-    - name: hapi
-      commands:
-      - cd javascript/hapi && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/hapi/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/hapi
-    - name: muneem
-      commands:
-      - cd javascript/muneem && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/muneem/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/muneem
-    - name: turbo_polka
-      commands:
-      - cd javascript/turbo_polka && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/turbo_polka/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/turbo_polka
-    - name: fyrejet-uwebsockets
-      commands:
-      - cd javascript/fyrejet-uwebsockets && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/fyrejet-uwebsockets/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/fyrejet-uwebsockets
-    - name: nanoexpress
-      commands:
-      - cd javascript/nanoexpress && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nanoexpress/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nanoexpress
-    - name: fyrejet
-      commands:
-      - cd javascript/fyrejet && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/fyrejet/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/fyrejet
-    - name: feathersjs
-      commands:
-      - cd javascript/feathersjs && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/feathersjs/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/feathersjs
-    - name: low-http-server
-      commands:
-      - cd javascript/low-http-server && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/low-http-server/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/low-http-server
-    - name: iotjs-express
-      commands:
-      - cd javascript/iotjs-express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/iotjs-express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/iotjs-express
-    - name: nestjs-express
-      commands:
-      - cd javascript/nestjs-express && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/nestjs-express/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/nestjs-express
-    - name: restify
-      commands:
-      - cd javascript/restify && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/restify/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/restify
-    - name: polkadot
-      commands:
-      - cd javascript/polkadot && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/polkadot/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/polkadot
-    - name: rayo
-      commands:
-      - cd javascript/rayo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/rayo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/rayo
-    - name: naturaljs-router
-      commands:
-      - cd javascript/naturaljs-router && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f javascript/naturaljs-router/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: javascript/naturaljs-router
     - name: tinyhttp
       commands:
       - cd javascript/tinyhttp && make build  -f .Makefile  && cd -
@@ -4217,11 +3843,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/tinyhttp
-    - name: sails
+    - name: restana
       commands:
-      - cd javascript/sails && make build  -f .Makefile  && cd -
+      - cd javascript/restana && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f javascript/sails/.Makefile collect
+      - make  -f javascript/restana/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -4233,7 +3859,58 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: javascript/sails
+        value: javascript/restana
+    - name: nestjs-fastify
+      commands:
+      - cd javascript/nestjs-fastify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nestjs-fastify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nestjs-fastify
+    - name: nestjs-express
+      commands:
+      - cd javascript/nestjs-express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nestjs-express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nestjs-express
+    - name: nanoexpress
+      commands:
+      - cd javascript/nanoexpress && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/nanoexpress/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/nanoexpress
     - name: fastify
       commands:
       - cd javascript/fastify && make build  -f .Makefile  && cd -
@@ -4251,6 +3928,312 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/fastify
+    - name: turbo_polka
+      commands:
+      - cd javascript/turbo_polka && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/turbo_polka/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/turbo_polka
+    - name: sifrr
+      commands:
+      - cd javascript/sifrr && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/sifrr/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/sifrr
+    - name: sails
+      commands:
+      - cd javascript/sails && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/sails/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/sails
+    - name: naturaljs-router
+      commands:
+      - cd javascript/naturaljs-router && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/naturaljs-router/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/naturaljs-router
+    - name: low-http-server
+      commands:
+      - cd javascript/low-http-server && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/low-http-server/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/low-http-server
+    - name: fyrejet
+      commands:
+      - cd javascript/fyrejet && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/fyrejet/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/fyrejet
+    - name: fyrejet-uwebsockets
+      commands:
+      - cd javascript/fyrejet-uwebsockets && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/fyrejet-uwebsockets/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/fyrejet-uwebsockets
+    - name: 0http
+      commands:
+      - cd javascript/0http && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/0http/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/0http
+    - name: hapi
+      commands:
+      - cd javascript/hapi && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/hapi/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/hapi
+    - name: restify
+      commands:
+      - cd javascript/restify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/restify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/restify
+    - name: rayo
+      commands:
+      - cd javascript/rayo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/rayo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/rayo
+    - name: polkadot
+      commands:
+      - cd javascript/polkadot && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/polkadot/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/polkadot
+    - name: polka
+      commands:
+      - cd javascript/polka && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/polka/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/polka
+    - name: muneem
+      commands:
+      - cd javascript/muneem && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/muneem/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/muneem
+    - name: iotjs-express
+      commands:
+      - cd javascript/iotjs-express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/iotjs-express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/iotjs-express
+    - name: foxify
+      commands:
+      - cd javascript/foxify && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/foxify/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/foxify
+    - name: feathersjs
+      commands:
+      - cd javascript/feathersjs && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/feathersjs/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/feathersjs
+    - name: express
+      commands:
+      - cd javascript/express && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/express/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/express
     - name: koa
       commands:
       - cd javascript/koa && make build  -f .Makefile  && cd -
@@ -4268,6 +4251,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: javascript/koa
+    - name: moleculer
+      commands:
+      - cd javascript/moleculer && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f javascript/moleculer/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: javascript/moleculer
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`
@@ -4348,6 +4348,57 @@ blocks:
       - bundle install
       - bundle exec rake config
     jobs:
+    - name: roda
+      commands:
+      - cd ruby/roda && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/roda/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/roda
+    - name: rack-routing
+      commands:
+      - cd ruby/rack-routing && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/rack-routing/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/rack-routing
+    - name: agoo
+      commands:
+      - cd ruby/agoo && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/agoo/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/agoo
     - name: syro
       commands:
       - cd ruby/syro && make build  -f .Makefile  && cd -
@@ -4382,6 +4433,23 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/sinatra
+    - name: rails
+      commands:
+      - cd ruby/rails && make build  -f .Makefile  && cd -
+      - bundle exec rspec .spec
+      - make  -f ruby/rails/.Makefile collect
+      - bundle exec rake db:raw_export
+      env_vars:
+      - name: DATABASE_URL
+        value: postgresql://postgres@0.0.0.0/benchmark
+      - name: DURATION
+        value: '10'
+      - name: CONCURRENCIES
+        value: '64'
+      - name: ROUTES
+        value: GET:/
+      - name: FRAMEWORK
+        value: ruby/rails
     - name: rack_app
       commands:
       - cd ruby/rack_app && make build  -f .Makefile  && cd -
@@ -4399,74 +4467,6 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/rack_app
-    - name: camping
-      commands:
-      - cd ruby/camping && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/camping/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/camping
-    - name: roda
-      commands:
-      - cd ruby/roda && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/roda/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/roda
-    - name: agoo
-      commands:
-      - cd ruby/agoo && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/agoo/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/agoo
-    - name: rack-routing
-      commands:
-      - cd ruby/rack-routing && make build  -f .Makefile  && cd -
-      - bundle exec rspec .spec
-      - make  -f ruby/rack-routing/.Makefile collect
-      - bundle exec rake db:raw_export
-      env_vars:
-      - name: DATABASE_URL
-        value: postgresql://postgres@0.0.0.0/benchmark
-      - name: DURATION
-        value: '10'
-      - name: CONCURRENCIES
-        value: '64'
-      - name: ROUTES
-        value: GET:/
-      - name: FRAMEWORK
-        value: ruby/rack-routing
     - name: hanami-api
       commands:
       - cd ruby/hanami-api && make build  -f .Makefile  && cd -
@@ -4518,11 +4518,11 @@ blocks:
         value: GET:/
       - name: FRAMEWORK
         value: ruby/cuba
-    - name: rails
+    - name: camping
       commands:
-      - cd ruby/rails && make build  -f .Makefile  && cd -
+      - cd ruby/camping && make build  -f .Makefile  && cd -
       - bundle exec rspec .spec
-      - make  -f ruby/rails/.Makefile collect
+      - make  -f ruby/camping/.Makefile collect
       - bundle exec rake db:raw_export
       env_vars:
       - name: DATABASE_URL
@@ -4534,7 +4534,7 @@ blocks:
       - name: ROUTES
         value: GET:/
       - name: FRAMEWORK
-        value: ruby/rails
+        value: ruby/camping
     epilogue:
       commands:
       - docker logs `cat ${FRAMEWORK}/cid.txt`

--- a/.tasks/ci.rake
+++ b/.tasks/ci.rake
@@ -38,9 +38,9 @@ namespace :ci do
         'bundle install',
         'bundle exec rake config'
       ] }, jobs: [] } }
-      Dir.glob("#{language}/*/config.yaml") do |file|
+      Dir.glob("#{language}/*/config.yaml").sort_by { |name| File.mtime(name) }.reverse!.each do |file|
         _, framework, = file.split(File::Separator)
-        next if language == 'php' && framework.start_with?('mixphp')
+
         block[:task][:jobs] << { name: framework, commands: [
           "cd #{language}/#{framework} && make build  -f #{MANIFESTS[:build]}  && cd -",
           'bundle exec rspec .spec',


### PR DESCRIPTION
Hi @onanying,

This `PR` take the 50 last modified frameworks in each language (only for CI, results will take all frameworks).

Until https://github.com/the-benchmarker/web-frameworks/pull/3958, I have no better solution.

Regards,